### PR TITLE
Fix maximum update depth exceeded error

### DIFF
--- a/src/pages/Root.jsx
+++ b/src/pages/Root.jsx
@@ -169,14 +169,8 @@ function Root() {
         break;
       }
       case 'product': {
-        const productSlug = rest[0] || '';
-        if (productSlug && products.length) {
-          const found = products.find(p => slugify(p['product-title']) === productSlug);
-          if (found) {
-            setSelectedProduct(found);
-            setShowProductDetailsPage(true);
-          }
-        }
+        // Product navigation is handled in a separate useEffect
+        // to avoid dependency on products array
         break;
       }
       case 'home':
@@ -254,7 +248,25 @@ function Root() {
     window.addEventListener('hashchange', handler);
     return () => window.removeEventListener('hashchange', handler);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [products]);
+  }, []);
+
+  // Handle product-specific navigation when products are loaded
+  useEffect(() => {
+    const hash = window.location.hash || '';
+    const [route, ...rest] = hash.replace(/^#/, '').split('/');
+    
+    // Only handle product navigation when products are available
+    if (route === 'product' && products.length > 0) {
+      const productSlug = rest[0] || '';
+      if (productSlug) {
+        const found = products.find(p => slugify(p['product-title']) === productSlug);
+        if (found && !showProductDetailsPage) {
+          setSelectedProduct(found);
+          setShowProductDetailsPage(true);
+        }
+      }
+    }
+  }, [products, showProductDetailsPage]);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
Refactor hash navigation to prevent infinite re-renders by separating product-specific logic from the main hash change effect.

The "Maximum update depth exceeded" error was caused by a circular dependency where the main hash navigation `useEffect` depended on `products`. Changes to `products` would trigger the effect, which called `navigateFromHash`, potentially causing further state changes that affected `products` and re-triggered the effect. This fix breaks the loop by removing `products` from the main effect's dependencies and introducing a separate `useEffect` for product-specific hash navigation that correctly depends on `products` and `showProductDetailsPage`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9efc2773-9711-4f67-909b-5ae996563843">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9efc2773-9711-4f67-909b-5ae996563843">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

